### PR TITLE
Fix initial position

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,10 @@ class Scrollspy {
     var index = this.targetIndices[change.target.id];
     if (change.intersectionRatio === 0) {
       var indexInViewPort = this.indicesInViewPort.indexOf(index);
-      this.indicesInViewPort.splice(indexInViewPort, 1);
+      
+      if (indexInViewport !== -1) {
+        this.indicesInViewPort.splice(indexInViewPort, 1);
+      }
     } else {
       if (index < oldTargetIndex) {
         this.indicesInViewPort.unshift(index);


### PR DESCRIPTION
Hi,

First of all thanks for this snippet. It's really useful :).

I've found a small issue in the observer code that can be reproduced on your demo as well. If you scroll down to the second (or third section), and reload the page, Chrome will preserve the scroll position but the scrolled item wont' be properly highlighted.

This has fixed the issue for me (and didn't break any thing).